### PR TITLE
Fix/improve server banner population graph

### DIFF
--- a/common/server-banner/image-banner.php
+++ b/common/server-banner/image-banner.php
@@ -118,10 +118,10 @@ if(extension_loaded('gd') && function_exists('gd_info'))
 			// compile graph
 			// build graph
 			$result = @mysqli_query($BF4stats,"
-				SELECT SUBSTRING(`TimeMapLoad`, 11, length(`TimeMapLoad`) - 16) AS Hourly, AVG(`MaxPlayers`) AS Average, MAX(`MaxPlayers`) AS Max
+				SELECT HOUR(`TimeMapLoad`) AS Hourly, AVG(`MaxPlayers`) AS Average, MAX(`MaxPlayers`) AS Max
 				FROM `tbl_mapstats`
 				WHERE `ServerID` = {$sid}
-				AND SUBSTRING(`TimeMapLoad`, 1, LENGTH(`TimeMapLoad`) - 9) BETWEEN CURDATE() - INTERVAL 24 HOUR AND CURDATE()
+				AND `TimeMapLoad` > NOW() - INTERVAL 24 HOUR
 				AND `Gamemode` != ''
 				AND `MapName` != ''
 				GROUP BY Hourly


### PR DESCRIPTION
### Fixes Issue Number: N/A


### Changes Proposed in this Pull Request:
Update query syntax that pulls player populations over the last 24 hours for the server banner images to fix wildly inconsistent and broke graphs

Caching of the images is still broken or inconsistent at best.  I haven't gotten around to looking into that yet.

This code can be seen in production at https://banzore.com

@tyger07
